### PR TITLE
beforeStateAccountFilter, tx.type verification and network account Id change

### DIFF
--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -10,7 +10,7 @@ import {DevSecurityLevel} from '@shardus/core'
 
 crypto.init('69fa4195670576c0160d660c3be36556ff8d504725be8a59b5a96509e0c994bc')
 
-export const networkAccount = '1000000000000000000000000000000000000000000000000000000000000001'
+export const networkAccount = '0'.repeat(64)
 
 // HELPFUL TIME CONSTANTS IN MILLISECONDS
 export const ONE_SECOND = 1000
@@ -44,7 +44,7 @@ export const TIME_FOR_DEV_APPLY = ONE_MINUTE + ONE_SECOND * 30
 
 // MIGHT BE USEFUL TO HAVE TIME CONSTANTS IN THE FORM OF CYCLES
 export const cycleDuration = 60
-const reduceTimeFromTxTimestamp = cycleDuration * ONE_MINUTE
+const reduceTimeFromTxTimestamp = cycleDuration * ONE_SECOND
 
 // INITIAL NETWORK PARAMETERS FOR LIBERDUS
 export const INITIAL_PARAMETERS: NetworkParameters = {

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -10,7 +10,7 @@ import {DevSecurityLevel} from '@shardus/core'
 
 crypto.init('69fa4195670576c0160d660c3be36556ff8d504725be8a59b5a96509e0c994bc')
 
-export const networkAccount = '0'.repeat(64)
+export const networkAccount = '1000000000000000000000000000000000000000000000000000000000000001'
 
 // HELPFUL TIME CONSTANTS IN MILLISECONDS
 export const ONE_SECOND = 1000
@@ -44,6 +44,7 @@ export const TIME_FOR_DEV_APPLY = ONE_MINUTE + ONE_SECOND * 30
 
 // MIGHT BE USEFUL TO HAVE TIME CONSTANTS IN THE FORM OF CYCLES
 export const cycleDuration = 60
+const reduceTimeFromTxTimestamp = cycleDuration * ONE_MINUTE
 
 // INITIAL NETWORK PARAMETERS FOR LIBERDUS
 export const INITIAL_PARAMETERS: NetworkParameters = {
@@ -456,7 +457,7 @@ config = merge(config, {
       stuckTxRemoveTime3: 300000, // 5 min
 
       awaitingDataCanBailOnReceipt: true,
-      reduceTimeFromTxTimestamp: 60000,
+      reduceTimeFromTxTimestamp,
     },
   },
 })

--- a/src/index.ts
+++ b/src/index.ts
@@ -134,13 +134,16 @@ dapp.setup({
       response.reason = 'Tx "type" field must be a string.'
       throw new Error(response.reason)
     }
+    if (transactions[tx.type] == undefined) {
+      response.success = false
+      response.reason = `The tx type ${tx.type} does not exist in the network.`
+    }
 
     if (typeof txnTimestamp !== 'number') {
       response.success = false
       response.reason = 'Tx "timestamp" field must be a number.'
       throw new Error(response.reason)
     }
-    console.log()
     return transactions[tx.type].validate_fields(tx, response)
   },
   getTimestampFromTransaction(tx: any) {
@@ -590,7 +593,10 @@ dapp.setup({
   binaryDeserializeObject: null,
   verifyMultiSigs: function (rawPayload: object, sigs: ShardusTypes.Sign[], allowedPubkeys: { [pubkey: string]: ShardusTypes.DevSecurityLevel }, minSigRequired: number, requiredSecurityLevel: ShardusTypes.DevSecurityLevel): boolean {
     return false
-  }
+  },
+  beforeStateAccountFilter(account: ShardusTypes.WrappedData) {
+    return false
+  },
 })
 
 dapp.registerExceptionHandler()


### PR DESCRIPTION
- Add verification check for tx.type of the user's injected tx is present in the transactions type list in the network
- Add beforeStateAccountFilter dapp function to flter out unnecessary before states getting forward to the archiver
- Change network account to 1[0*52]1 
Github issue link -> https://github.com/Liberdus/server/issues/5

PR for #5 