### PR TITLE
Fix version comparison bug

### DIFF
--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -658,15 +658,20 @@ export function isEqualOrNewerVersion(minimumVersion: string, testVersion: strin
 
   const minVerParts = minimumVersion.split('.')
   const testVerParts = testVersion.split('.')
+  const maxLen = Math.max(minVerParts.length, testVerParts.length)
+
   /* eslint-disable security/detect-object-injection */
-  for (let i = 0; i < testVerParts.length; i++) {
-    const testV = ~~testVerParts[i] // parse int
-    const minV = ~~minVerParts[i] // parse int
+  for (let i = 0; i < maxLen; i++) {
+    const testV = parseInt(testVerParts[i] || '0', 10)
+    const minV = parseInt(minVerParts[i] || '0', 10)
+
     if (testV > minV) return true
     if (testV < minV) return false
   }
   /* eslint-enable security/detect-object-injection */
-  return false
+
+  // Versions are equal
+  return true
 }
 
 /**

--- a/test/versionFunctions.test.ts
+++ b/test/versionFunctions.test.ts
@@ -1,0 +1,17 @@
+import { isEqualOrNewerVersion, isEqualOrOlderVersion } from '../src/utils'
+
+describe('version comparison helpers', () => {
+  test('isEqualOrNewerVersion correctly compares versions with different lengths', () => {
+    expect(isEqualOrNewerVersion('1.2.3', '1.2.3')).toBe(true)
+    expect(isEqualOrNewerVersion('1.2.3', '1.2.4')).toBe(true)
+    expect(isEqualOrNewerVersion('1.2.3', '1.3')).toBe(true)
+    expect(isEqualOrNewerVersion('1.2.3', '1.2')).toBe(false)
+  })
+
+  test('isEqualOrOlderVersion correctly compares versions', () => {
+    expect(isEqualOrOlderVersion('1.2.3', '1.2.3')).toBe(true)
+    expect(isEqualOrOlderVersion('1.2.3', '1.2.2')).toBe(true)
+    expect(isEqualOrOlderVersion('1.2.3', '1.1')).toBe(true)
+    expect(isEqualOrOlderVersion('1.2.3', '1.2.4')).toBe(false)
+  })
+})


### PR DESCRIPTION
## Summary
- fix comparison logic for versions to handle different length strings
- add unit tests for version helpers

## Testing
- `npm test` *(fails: Cannot read file '/workspace/server/node_modules/gts/tsconfig-google.json')*
- `npm run compile` *(fails: Cannot read file '/workspace/server/node_modules/gts/tsconfig-google.json')*

------
https://chatgpt.com/codex/tasks/task_e_686b4502f3248328bbb9ee56dbaea4f1