### PR TITLE
Deprecates old transaction types

### DIFF
--- a/client.js
+++ b/client.js
@@ -533,7 +533,7 @@ function calculateChatId(to, from) {
 
 async function queryMessages(to, from) {
   try {
-    const res = await axios.get(`${PROTOCOL}://${HOST}/messages/${calculateChatId(USER.address, to)}`)
+    const res = await axios.get(`${PROTOCOL}://${HOST}/messages/${calculateChatId(USER.address, to)}/0`)
     const { messages } = res.data
     return messages
   } catch (error) {
@@ -807,6 +807,7 @@ vorpal.command('email', 'registers your email address to the network').action(as
     signedTx,
     email: answer.email,
     timestamp: Date.now(),
+    networkId,
   }
   injectTx(tx).then((res) => {
     this.log(res)

--- a/docs/API.md
+++ b/docs/API.md
@@ -165,17 +165,25 @@ Returns address information for the given name.
 - `name`: Account name
 
 ### GET /account/:id/:friendId/toll
+⚠️ **DEPRECATED** - Deprecated in version 2.5.0. This endpoint will be removed in a future version.
+
 Returns toll information between two accounts.
 
 **Parameters:**
 - `id`: Account identifier
 - `friendId`: Friend's account identifier
 
+**Note:** This endpoint is deprecated because the friend functionality has been removed. Use `/account/:id/toll` instead.
+
 ### GET /account/:id/friends
+⚠️ **DEPRECATED** - Deprecated in version 2.5.0. This endpoint will be removed in a future version.
+
 Returns friends list for the given account ID.
 
 **Parameters:**
 - `id`: Account identifier
+
+**Note:** This endpoint is deprecated because the friend functionality has been removed.
 
 ### GET /account/:id/recentMessages
 Returns recent messages for the given account ID.

--- a/docs/API.md
+++ b/docs/API.md
@@ -509,7 +509,9 @@ The transaction will:
 2. Add amount to target account
 3. Update timestamps for both accounts
 
-#### `email`
+#### `email` ⚠️ DEPRECATED
+**Deprecated in version 2.5.0** - This transaction type is deprecated and will be removed in a future version. New transactions of this type will be rejected when network version >= 2.5.0.
+
 Initiates the email verification process for an account.
 
 **Transaction Parameters:**
@@ -541,7 +543,9 @@ The transaction will:
 3. Store email hash and verification code hash
 4. Trigger gossip_email_hash transaction
 
-#### `gossip_email_hash`
+#### `gossip_email_hash` ⚠️ DEPRECATED
+**Deprecated in version 2.5.0** - This transaction type is deprecated and will be removed in a future version. New transactions of this type will be rejected when network version >= 2.5.0.
+
 Internal transaction to propagate email verification data across nodes.
 
 **Transaction Parameters:**
@@ -559,7 +563,9 @@ Internal transaction to propagate email verification data across nodes.
 
 This transaction is automatically triggered by the system after an email transaction and should not be manually created.
 
-#### `verify`
+#### `verify` ⚠️ DEPRECATED
+**Deprecated in version 2.5.0** - This transaction type is deprecated and will be removed in a future version. New transactions of this type will be rejected when network version >= 2.5.0.
+
 Completes the email verification process using the code received via email.
 
 **Transaction Parameters:**
@@ -663,7 +669,9 @@ The transaction will:
 4. Update chat references for both users
 5. Update timestamps for all affected accounts
 
-#### `friend`
+#### `friend` ⚠️ DEPRECATED
+**Deprecated in version 2.5.0** - This transaction type is deprecated and will be removed in a future version. New transactions of this type will be rejected when network version >= 2.5.0.
+
 Adds another user as a friend to avoid toll payments for messaging.
 
 **Transaction Parameters:**
@@ -722,7 +730,9 @@ The transaction will:
 
 Note: If a user has not set a toll amount, the system's default toll will be used for messages from non-friends.
 
-#### `remove_friend`
+#### `remove_friend` ⚠️ DEPRECATED
+**Deprecated in version 2.5.0** - This transaction type is deprecated and will be removed in a future version. New transactions of this type will be rejected when network version >= 2.5.0.
+
 Removes a friend from the user's friend list, requiring toll payments for future messages.
 
 **Transaction Parameters:**

--- a/src/@types/index.ts
+++ b/src/@types/index.ts
@@ -23,8 +23,11 @@ export enum AJVSchemaEnum {
   init_network = 'init_network',
   network_windows = 'network_windows',
   snapshot = 'snapshot',
+  /** @deprecated Deprecated in version 2.5.0 - will be removed in a future version */
   email = 'email',
+  /** @deprecated Deprecated in version 2.5.0 - will be removed in a future version */
   gossip_email_hash = 'gossip_email_hash',
+  /** @deprecated Deprecated in version 2.5.0 - will be removed in a future version */
   verify = 'verify',
   register = 'register',
   create = 'create',
@@ -36,7 +39,9 @@ export enum AJVSchemaEnum {
   update_chat_toll = 'update_chat_toll',
   update_toll_required = 'update_toll_required',
   toll = 'toll',
+  /** @deprecated Deprecated in version 2.5.0 - will be removed in a future version */
   friend = 'friend',
+  /** @deprecated Deprecated in version 2.5.0 - will be removed in a future version */
   remove_friend = 'remove_friend',
   stake = 'stake',
   remove_stake = 'remove_stake',
@@ -76,8 +81,11 @@ export enum TXTypes {
   init_network = 'init_network',
   network_windows = 'network_windows',
   snapshot = 'snapshot',
+  /** @deprecated Deprecated in version 2.5.0 - will be removed in a future version */
   email = 'email',
+  /** @deprecated Deprecated in version 2.5.0 - will be removed in a future version */
   gossip_email_hash = 'gossip_email_hash',
+  /** @deprecated Deprecated in version 2.5.0 - will be removed in a future version */
   verify = 'verify',
   register = 'register',
   create = 'create',
@@ -89,7 +97,9 @@ export enum TXTypes {
   update_chat_toll = 'update_chat_toll',
   update_toll_required = 'update_toll_required',
   toll = 'toll',
+  /** @deprecated Deprecated in version 2.5.0 - will be removed in a future version */
   friend = 'friend',
+  /** @deprecated Deprecated in version 2.5.0 - will be removed in a future version */
   remove_friend = 'remove_friend',
   stake = 'stake',
   remove_stake = 'remove_stake',

--- a/src/@types/transactionSchemas.ts
+++ b/src/@types/transactionSchemas.ts
@@ -151,6 +151,7 @@ export const schemaDistributeTX = {
   additionalProperties: false,
 }
 
+// @deprecated Deprecated in version 2.5.0 - will be removed in a future version
 export const schemaEmailTX = {
   type: 'object',
   properties: {
@@ -171,6 +172,7 @@ export const schemaEmailTX = {
   additionalProperties: false,
 }
 
+// @deprecated Deprecated in version 2.5.0 - will be removed in a future version
 export const schemaFriendTX = {
   type: 'object',
   properties: {
@@ -183,6 +185,7 @@ export const schemaFriendTX = {
   additionalProperties: false,
 }
 
+// @deprecated Deprecated in version 2.5.0 - will be removed in a future version
 export const schemaGossipEmailHashTX = {
   type: 'object',
   properties: {
@@ -428,6 +431,7 @@ export const schemaRegisterTX = {
   additionalProperties: false,
 }
 
+// @deprecated Deprecated in version 2.5.0 - will be removed in a future version
 export const schemaRemoveFriendTX = {
   type: 'object',
   properties: {
@@ -536,6 +540,7 @@ export const schemaTollTX = {
   additionalProperties: false,
 }
 
+// @deprecated Deprecated in version 2.5.0 - will be removed in a future version
 export const schemaVerifyTX = {
   type: 'object',
   properties: {

--- a/src/api/accounts/friends.ts
+++ b/src/api/accounts/friends.ts
@@ -1,5 +1,22 @@
+import * as AccountsStorage from '../../storage/accountStorage'
+import * as utils from '../../utils'
+
 export const friends = dapp => async (req, res): Promise<void> => {
   try {
+    // Deprecation check - reject when network version >= 2.5.0
+    // This check is disabled until network version is flipped to 2.5.0 or higher
+    if (
+      AccountsStorage?.cachedNetworkAccount &&
+      utils.isEqualOrNewerVersion('2.5.0', AccountsStorage.cachedNetworkAccount.current.activeVersion)
+    ) {
+      res.status(410).json({
+        error: 'This endpoint is deprecated and no longer available',
+        deprecated: true,
+        deprecatedVersion: '2.5.0',
+      })
+      return
+    }
+
     const id = req.params['id']
     const account = await dapp.getLocalOrRemoteAccount(id)
     if (account) {

--- a/src/api/accounts/tollOfFriend.ts
+++ b/src/api/accounts/tollOfFriend.ts
@@ -4,6 +4,20 @@ import * as AccountsStorage from '../../storage/accountStorage'
 
 export const tollOfFriend = dapp => async (req, res): Promise<void> => {
   try {
+    // Deprecation check - reject when network version >= 2.5.0
+    // This check is disabled until network version is flipped to 2.5.0 or higher
+    if (
+      AccountsStorage?.cachedNetworkAccount &&
+      utils.isEqualOrNewerVersion('2.5.0', AccountsStorage.cachedNetworkAccount.current.activeVersion)
+    ) {
+      res.status(410).json({
+        error: 'This endpoint is deprecated and no longer available',
+        deprecated: true,
+        deprecatedVersion: '2.5.0',
+      })
+      return
+    }
+
     const id = req.params['id']
     const friendId = req.params['friendId']
     if (!id) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -246,6 +246,15 @@ const shardusSetup = (): void => {
           return validationResult
         }
 
+        // 3.5. Check for deprecated transaction types (version-based deprecation >= 2.5.0)
+        if (AccountsStorage?.cachedNetworkAccount && utils.isEqualOrNewerVersion('2.5.0', AccountsStorage.cachedNetworkAccount.current.activeVersion)) {
+          const deprecatedTxTypes = [TXTypes.email, TXTypes.gossip_email_hash, TXTypes.verify, TXTypes.friend, TXTypes.remove_friend]
+          if (deprecatedTxTypes.includes(tx.type)) {
+            validationResult.reason = `Transaction type "${tx.type}" is deprecated from version 2.5.0 onwards and no longer accepted`
+            return validationResult
+          }
+        }
+
         // 4. Validate the tx fields
         if (LiberdusFlags.enableAJVValidation) {
           const errors = verifyPayload(tx.type, tx)


### PR DESCRIPTION
Deprecates specific transaction types and API endpoints in preparation for a future version.

This change introduces the following:

- Marks old transaction types (`email`, `gossip_email_hash`, `verify`, `friend`, `remove_friend`) as deprecated in the code using JSDoc tags.
- Adds a version-based check to reject deprecated transaction types and API requests (friends, tollOfFriend) when the network version is 2.5.0 or higher.
- Returns a 410 status code for deprecated API endpoints.