### PR TITLE
feat: record update toll required in chat history

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "liberdus",
-  "version": "2.4.8",
+  "version": "2.4.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "liberdus",
-      "version": "2.4.8",
+      "version": "2.4.9",
       "license": "ISC",
       "dependencies": {
         "@shardus/core": "2.16.0-prerelease.11",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "liberdus",
-  "version": "2.4.8",
+  "version": "2.4.9",
   "description": "Liberdus is a payment network that allows users to govern their own money system in a democratic fashion",
   "main": "dist/index.js",
   "scripts": {

--- a/src/@types/index.ts
+++ b/src/@types/index.ts
@@ -272,9 +272,12 @@ export namespace Tx {
     to: string
     chatId: string
     required: number // 1 if toll required, 0 if not nd 2 to block other party
+    previousRequired?: number
     timestamp: number // timestamp up to which messages are considered read
     fee?: bigint // Optional fee for the update toll transaction
   }
+
+  export type ChatMessageRecord = MessageRecord | Transfer | Read | UpdateTollRequired
 
   export interface ReclaimToll extends BaseLiberdusTx {
     from: string
@@ -587,7 +590,7 @@ export interface ChatAccount {
   hash: string
   type: string
   timestamp: number
-  messages: (Tx.MessageRecord | Tx.Transfer | Tx.Read)[]
+  messages: Tx.ChatMessageRecord[]
   toll: {
     required: [number, number] // 1 if toll required, 0 if not
     payOnRead: [bigint, bigint] // amount to be paid when reading

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -252,6 +252,7 @@ interface LiberdusFlags {
     nodeRewardedStatusCheck: boolean
     weiToLibStringFormat: boolean
     includeTxToKeyInReadTx: boolean
+    updateTollRequiredTxInChatHistory: boolean
   }
 }
 
@@ -296,6 +297,7 @@ export const LiberdusFlags: LiberdusFlags = {
     nodeRewardedStatusCheck: true, // turn on by 2.4.8
     weiToLibStringFormat: true, // turn on by 2.4.8
     includeTxToKeyInReadTx: true, // turn on by 2.4.8
+    updateTollRequiredTxInChatHistory: false, // turn on by 2.4.9
   },
 }
 

--- a/src/transactions/update_toll_required.ts
+++ b/src/transactions/update_toll_required.ts
@@ -1,6 +1,7 @@
 import * as crypto from '../crypto'
 import { Shardus, ShardusTypes } from '@shardus/core'
 import * as utils from '../utils'
+import * as config from '../config'
 import { UserAccount, ChatAccount, WrappedStates, Tx, AppReceiptData } from '../@types'
 import create from '../accounts'
 import { SafeBigIntMath } from '../utils/safeBigIntMath'
@@ -167,6 +168,10 @@ export const apply = (
   chat.timestamp = txTimestamp
   from.timestamp = txTimestamp
 
+  if (config.LiberdusFlags.versionFlags.updateTollRequiredTxInChatHistory) {
+    chat.messages.push(tx)
+  }
+
   const appReceiptData: AppReceiptData = {
     txId,
     timestamp: txTimestamp,
@@ -218,14 +223,14 @@ export const createFailedAppReceiptData = (
   dapp.applyResponseAddReceiptData(applyResponse, appReceiptData, appReceiptDataHash)
 }
 
-export const keys = (tx: Tx.Read, result: ShardusTypes.TransactionKeys): ShardusTypes.TransactionKeys => {
+export const keys = (tx: Tx.UpdateTollRequired, result: ShardusTypes.TransactionKeys): ShardusTypes.TransactionKeys => {
   result.sourceKeys = [tx.chatId, tx.from]
   result.targetKeys = [tx.to]
   result.allKeys = [...result.sourceKeys, ...result.targetKeys]
   return result
 }
 
-export const memoryPattern = (tx: Tx.Read, result: ShardusTypes.TransactionKeys): ShardusTypes.ShardusMemoryPatternsInput => {
+export const memoryPattern = (tx: Tx.UpdateTollRequired, result: ShardusTypes.TransactionKeys): ShardusTypes.ShardusMemoryPatternsInput => {
   return {
     rw: [tx.from, tx.to, tx.chatId], // to account is somewhat needed
     wo: [],
@@ -239,7 +244,7 @@ export const createRelevantAccount = (
   dapp: Shardus,
   account: UserAccount | ChatAccount,
   accountId: string,
-  tx: Tx.Read,
+  tx: Tx.UpdateTollRequired,
   accountCreated = false,
 ): ShardusTypes.WrappedResponse => {
   if (!account) {

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -54,7 +54,7 @@ export function calculateAccountHash(account: Accounts): string {
   return account.hash
 }
 
-export function isMessageRecord(message: Tx.MessageRecord | Tx.Transfer | Tx.Read): message is Tx.MessageRecord {
+export function isMessageRecord(message: Tx.ChatMessageRecord): message is Tx.MessageRecord {
   return message.type === TXTypes.message
 }
 

--- a/src/versioning/index.ts
+++ b/src/versioning/index.ts
@@ -17,7 +17,7 @@ const appliedMigrations = new Set<string>()
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
 export const onActiveVersionChange = async (newActiveVersion: string) => {
   // For future migrations, add a file under ./migrations and add the version here
-  const migrations = ['2.3.5', '2.3.6', '2.3.7', '2.3.8', '2.4.1', '2.4.5', '2.4.8']
+  const migrations = ['2.3.5', '2.3.6', '2.3.7', '2.3.8', '2.4.1', '2.4.5', '2.4.8', '2.4.9']
 
   for (let index = 0; index < migrations.length; index++) {
     const migrationVersion = migrations[index] // eslint-disable-line security/detect-object-injection

--- a/src/versioning/migrations/2.4.9.ts
+++ b/src/versioning/migrations/2.4.9.ts
@@ -1,0 +1,10 @@
+import { nestedCountersInstance } from '@shardus/core'
+import { Migration } from '../types'
+import { LiberdusFlags } from '../../config'
+
+export const migrate: Migration = async () => {
+  console.log('migrate 2.4.9')
+  nestedCountersInstance.countEvent('migrate', 'calling migrate 2.4.9')
+
+  LiberdusFlags.versionFlags.updateTollRequiredTxInChatHistory = true
+}


### PR DESCRIPTION
- Add updateTollRequiredTxInChatHistory version flag and 2.4.9 migration.

- Store update_toll_required transactions in chat history when the flag is enabled.

- Include optional previousRequired in the update_toll_required tx type for client-provided payloads.

- Keep default network active/min/latest versions at 2.4.8 while bumping package metadata to 2.4.9.