### PR TITLE
Index toll status updates for both chat participants

### DIFF
--- a/src/@types/index.ts
+++ b/src/@types/index.ts
@@ -274,6 +274,7 @@ export namespace Tx {
     required: number // 1 if toll required, 0 if not nd 2 to block other party
     previousRequired?: number
     timestamp: number // timestamp up to which messages are considered read
+    chatTimestamp?: number // server-applied chat timestamp for chat history/discovery
     fee?: bigint // Optional fee for the update toll transaction
   }
 

--- a/src/@types/index.ts
+++ b/src/@types/index.ts
@@ -274,7 +274,6 @@ export namespace Tx {
     required: number // 1 if toll required, 0 if not nd 2 to block other party
     previousRequired?: number
     timestamp: number // timestamp up to which messages are considered read
-    chatTimestamp?: number // server-applied chat timestamp for chat history/discovery
     fee?: bigint // Optional fee for the update toll transaction
   }
 

--- a/src/transactions/update_toll_required.ts
+++ b/src/transactions/update_toll_required.ts
@@ -181,10 +181,7 @@ export const apply = (
   to.data.chatTimestamp = txTimestamp
 
   if (config.LiberdusFlags.versionFlags.updateTollRequiredTxInChatHistory) {
-    chat.messages.push({
-      ...tx,
-      chatTimestamp: txTimestamp,
-    })
+    chat.messages.push(tx)
   }
 
   const appReceiptData: AppReceiptData = {

--- a/src/transactions/update_toll_required.ts
+++ b/src/transactions/update_toll_required.ts
@@ -181,7 +181,10 @@ export const apply = (
   to.data.chatTimestamp = txTimestamp
 
   if (config.LiberdusFlags.versionFlags.updateTollRequiredTxInChatHistory) {
-    chat.messages.push(tx)
+    chat.messages.push({
+      ...tx,
+      chatTimestamp: txTimestamp,
+    })
   }
 
   const appReceiptData: AppReceiptData = {

--- a/src/transactions/update_toll_required.ts
+++ b/src/transactions/update_toll_required.ts
@@ -167,21 +167,17 @@ export const apply = (
   // Update timestamps
   chat.timestamp = txTimestamp
   from.timestamp = txTimestamp
-  to.timestamp = txTimestamp
-
-  from.data.chats[tx.to] = {
-    receivedTimestamp: txTimestamp,
-    chatId: tx.chatId,
-  }
-  from.data.chatTimestamp = txTimestamp
-  to.data.chats[tx.from] = {
-    receivedTimestamp: txTimestamp,
-    chatId: tx.chatId,
-  }
-  to.data.chatTimestamp = txTimestamp
 
   if (config.LiberdusFlags.versionFlags.updateTollRequiredTxInChatHistory) {
     chat.messages.push(tx)
+
+    // Update both participants' chat indexes so the toll status change is immediately
+    // discoverable via /account/:id/chats/:timestamp without waiting for a subsequent message
+    from.data.chats[tx.to] = { receivedTimestamp: txTimestamp, chatId: tx.chatId }
+    from.data.chatTimestamp = txTimestamp
+    to.data.chats[tx.from] = { receivedTimestamp: txTimestamp, chatId: tx.chatId }
+    to.data.chatTimestamp = txTimestamp
+    to.timestamp = txTimestamp
   }
 
   const appReceiptData: AppReceiptData = {

--- a/src/transactions/update_toll_required.ts
+++ b/src/transactions/update_toll_required.ts
@@ -167,6 +167,18 @@ export const apply = (
   // Update timestamps
   chat.timestamp = txTimestamp
   from.timestamp = txTimestamp
+  to.timestamp = txTimestamp
+
+  from.data.chats[tx.to] = {
+    receivedTimestamp: txTimestamp,
+    chatId: tx.chatId,
+  }
+  from.data.chatTimestamp = txTimestamp
+  to.data.chats[tx.from] = {
+    receivedTimestamp: txTimestamp,
+    chatId: tx.chatId,
+  }
+  to.data.chatTimestamp = txTimestamp
 
   if (config.LiberdusFlags.versionFlags.updateTollRequiredTxInChatHistory) {
     chat.messages.push(tx)


### PR DESCRIPTION
## Summary
- Updates both sender and recipient user chat indexes when an update_toll_required transaction is applied.
- Advances both participants' chatTimestamp values so status-only chat history is discoverable from /account/:id/chats/:timestamp.
- Keeps the chat.messages append behavior introduced by #88.

## Why
The web-client two-sided validation exposed that server#88 stores the status tx in chat.messages, but a fresh recipient session does not discover the chat because the recipient's user chat index is not touched. This patch makes the status event visible to both sides, including a new-device recipient load.

## Verification
- npm ci: blocked locally by @shardeum-foundation/lib-net Rust build under Node v23.5.0 / current Rust toolchain: unused import denied by #![deny(warnings)].
- npm ci --ignore-scripts: passed.
- npm run compile: passed.