### PR TITLE
fix(dao): correct default voteExponent from 1.1 to 0.1

### DIFF
--- a/client.js
+++ b/client.js
@@ -2683,7 +2683,7 @@ vorpal.command('dao proposal create', 'create a new DAO governance/economic/prot
     {
       type: 'input',
       name: 'changesJson',
-      message: 'Enter parameter changes as JSON array (e.g. [{"key":"voteExponent","value":"1.2","current":"1.1"}]):',
+      message: 'Enter parameter changes as JSON array (e.g. [{"key":"voteExponent","value":"0.2","current":"0.1"}]):',
       default: '[]',
     },
     {

--- a/scripts/dao-vote-calculator.ts
+++ b/scripts/dao-vote-calculator.ts
@@ -39,7 +39,7 @@ const SCENARIOS: Scenario[] = [
     votingDuration: 90,
     emergency: false,
     minimumSpendLib: 1,
-    voteExponent: 1.1,
+    voteExponent: 0.1,
     spendLib: 200,
     weights: [1, 2, 1],
     castAtOffsetFromVotingStart: 10, // well within first half (halfDuration = 45s)
@@ -51,7 +51,7 @@ const SCENARIOS: Scenario[] = [
     votingDuration: 90,
     emergency: false,
     minimumSpendLib: 1,
-    voteExponent: 1.1,
+    voteExponent: 0.1,
     spendLib: 200,
     weights: [1, 2, 1],
     castAtOffsetFromVotingStart: 45, // == halfDuration
@@ -63,7 +63,7 @@ const SCENARIOS: Scenario[] = [
     votingDuration: 90,
     emergency: false,
     minimumSpendLib: 1,
-    voteExponent: 1.1,
+    voteExponent: 0.1,
     spendLib: 200,
     weights: [1, 2, 1],
     castAtOffsetFromVotingStart: 67, // 45 + 22.5 -> ~half of the second half elapsed
@@ -75,7 +75,7 @@ const SCENARIOS: Scenario[] = [
     votingDuration: 90,
     emergency: false,
     minimumSpendLib: 1,
-    voteExponent: 1.1,
+    voteExponent: 0.1,
     spendLib: 200,
     weights: [1, 2, 1],
     castAtOffsetFromVotingStart: 90, // == votingDuration -> at votingEnd
@@ -87,7 +87,7 @@ const SCENARIOS: Scenario[] = [
     votingDuration: 90,
     emergency: false,
     minimumSpendLib: 1,
-    voteExponent: 1.1,
+    voteExponent: 0.1,
     spendLib: 1000,
     weights: [1, 1],
     castAtOffsetFromVotingStart: 0,
@@ -99,7 +99,7 @@ const SCENARIOS: Scenario[] = [
     votingDuration: 90,
     emergency: false,
     minimumSpendLib: 1,
-    voteExponent: 1.1,
+    voteExponent: 0.1,
     spendLib: 200,
     weights: [1, 0, 0],
     castAtOffsetFromVotingStart: 0,

--- a/scripts/test-dao-e2e.ts
+++ b/scripts/test-dao-e2e.ts
@@ -2123,7 +2123,7 @@ async function main(): Promise<void> {
   const minVoteSpendLib = usdStrToLibCeil(minimumSpendUsdStr, stabilityFactorStr)
   console.log(`Funding: ${TEST_ACCOUNT_FUND_LIB} LIB per account; min dao_vote spend≈${minVoteSpendLib} LIB`)
 
-  let sc1VoteExponentTarget = 1.2
+  let sc1VoteExponentTarget = 0.2
   let sc4PctBurnedTarget = 70
   let sc17VoteThresholdUsdTarget = '150.0'
   let sc17UnapplyThreshold = 3
@@ -2150,11 +2150,11 @@ async function main(): Promise<void> {
     name: 'Scenario 1 — Happy path (governance → accepted → applied → claimed)',
     setupSteps: [
     [
-      '1.2  dao_proposal_create (governance: voteExponent 1.1 → 1.2)',
+      '1.2  dao_proposal_create (governance: toggle voteExponent)',
       async () => {
         const daoParams = await getDaoParameters()
         const currentVoteExponent = Number(daoParams.voteExponent)
-        sc1VoteExponentTarget = currentVoteExponent === 1.2 ? 1.1 : 1.2
+        sc1VoteExponentTarget = currentVoteExponent === 0.2 ? 0.1 : 0.2
         const proposalFeeWei = usdStrToLibWei(daoParams.proposalFeeUsdStr, stabilityFactorStr)
         setProposalN('sc1', await createDaoProposal({
           proposer,
@@ -2976,7 +2976,7 @@ async function main(): Promise<void> {
           title: 'Weighted multi-option vote',
           description: 'Multi-option weighted vote test proposal',
           options: ['yes', 'no', 'abstain'],
-          changes: [{ key: 'voteExponent', value: '1.2', current: '1.5' }],
+          changes: [{ key: 'voteExponent', value: '0.3', current: '0.1' }],
           gracePeriodMs: graceDurationMs,
         }))
         saveCurrentRunState()

--- a/src/accounts/daoProposalAccount.ts
+++ b/src/accounts/daoProposalAccount.ts
@@ -20,7 +20,7 @@ export function daoProposalAccount(id: string): DaoProposalAccount {
     proposalFeeUsdStr: '0',
     voteThresholdUsdStr: '0',
     minimumSpendUsdStr: '0',
-    voteExponent: 1.1,
+    voteExponent: 0.1,
     pctBurned: 50,
     reviewDuration: 0,
     votingDuration: 0,

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -110,7 +110,7 @@ export const INITIAL_PARAMETERS: NetworkParameters = {
     proposalFeeUsdStr: '50.0',
     voteThresholdUsdStr: '100.0',
     minimumSpendUsdStr: '1.0',
-    voteExponent: 1.1,
+    voteExponent: 0.1,
     pctBurned: 50,
     reviewDuration: daoReviewDurationMs,
     votingDuration: daoVotingDurationMs,

--- a/test/daoVoteMath.test.ts
+++ b/test/daoVoteMath.test.ts
@@ -52,7 +52,7 @@ describe('getTimeMultiplier', () => {
 
 describe('calculateVoteWeightDetails', () => {
   const minimumSpendWei = 1n * LIB      // 1 LIB minimum
-  const voteExponent = 1.1
+  const voteExponent = 0.1
   const timeMultiplier = new DaoDecimal(1) // full weight (first half)
 
   test('spend equal to minimum gives spendBoost of 1', () => {
@@ -66,7 +66,7 @@ describe('calculateVoteWeightDetails', () => {
     expect(spendBoost.toNumber()).toBeCloseTo(1)
   })
 
-  test('spend 10x minimum gives spendBoost of 10^1.1', () => {
+  test('spend 10x minimum gives spendBoost of 10^0.1', () => {
     const { spendBoost } = calculateVoteWeightDetails({
       spend: 10n * LIB,
       minimumSpendWei,
@@ -74,7 +74,7 @@ describe('calculateVoteWeightDetails', () => {
       weights: [1],
       timeMultiplier,
     })
-    expect(spendBoost.toNumber()).toBeCloseTo(Math.pow(10, 1.1))
+    expect(spendBoost.toNumber()).toBeCloseTo(Math.pow(10, 0.1))
   })
 
   test('spendInLIB converts wei to LIB correctly', () => {
@@ -108,7 +108,7 @@ describe('calculateVoteWeightDetails', () => {
 
 describe('calculateOptionWeights', () => {
   const minimumSpendWei = 1n * LIB
-  const voteExponent = 1.1
+  const voteExponent = 0.1
   const timeMultiplier = new DaoDecimal(1)
   const spend = 1n * LIB // exactly minimum → spendBoost = 1
 
@@ -158,7 +158,9 @@ describe('calculateOptionWeights', () => {
   test('higher spend produces proportionally higher weights', () => {
     const base   = calculateOptionWeights({ spend: 1n * LIB,  minimumSpendWei, voteExponent, weights: [1], timeMultiplier })
     const double = calculateOptionWeights({ spend: 2n * LIB,  minimumSpendWei, voteExponent, weights: [1], timeMultiplier })
-    // spendBoost = (2/1)^1.1 > 2, and spendInLIB doubles → weight more than doubles
+    // baseWeight = spendInLIB * spendBoost ∝ spend^(1 + voteExponent); doubling spend always
+    // more than doubles the weight as long as voteExponent > 0 (here (2/1)^0.1 ≈ 1.07, on top
+    // of spendInLIB itself doubling)
     expect(double[0]).toBeGreaterThan(base[0] * 2n)
   })
 })


### PR DESCRIPTION
- Matches the fixed Liberdus DAO Voting Policy, which corrects the vote weight formula's exponent from 1.1 to 0.1
- Changed the network genesis default and the proposal factory default
- The formula already multiplies by voteSpend linearly outside the ratio boost, so an exponent of 1.1 there made the effective weight scale as voteSpend^2.1 instead of the intended mild voteSpend^1.1
- Updated E2E Scenario 1/7 to use the corrected 0.1/0.2/0.3 range instead of the stale 1.1/1.2/1.5 values, with distinct target values per scenario so a --parallel run can't let one scenario's proposal masquerade as another's when both touch the same network parameter
- Fixed a stale sc1VoteExponentTarget initial value in the E2E harness that would've made a standalone --step 1.11 rerun poll forever
- Synced scripts/dao-vote-calculator.ts's example scenarios to 0.1
- Synced test/daoVoteMath.test.ts's fixtures to 0.1 for consistency, even though the math itself is exponent-agnostic