### PR TITLE
feat(dao): support multi-option proposal change sets

### DIFF
--- a/client.js
+++ b/client.js
@@ -2615,6 +2615,18 @@ function asBigIntForDisplay(value) {
   return 0n
 }
 
+function formatDaoProposalChanges(p) {
+  const payload = p.governance || p.economic || p.protocol
+  const changes = payload?.changes
+  if (!Array.isArray(changes)) return ''
+  if (Array.isArray(changes[0])) {
+    return changes
+      .map((changeSet, i) => `${p.options?.[i + 1] || `option ${i + 1}`}: ${JSON.stringify(changeSet)}`)
+      .join('\n              ')
+  }
+  return JSON.stringify(changes)
+}
+
 // Mirrors utils.usdStrToWei on the server — converts a USD-string snapshot to Wei at the
 // given exchange rate.
 function usdStrToWei(usdStr, stabilityFactorStr) {
@@ -2677,13 +2689,13 @@ vorpal.command('dao proposal create', 'create a new DAO governance/economic/prot
     {
       type: 'input',
       name: 'options',
-      message: 'Enter ballot options as comma-separated list (e.g. no,yes):',
+      message: 'Enter ballot options as comma-separated list (e.g. no,Increase burn,Decrease burn):',
       default: 'no,yes',
     },
     {
       type: 'input',
       name: 'changesJson',
-      message: 'Enter parameter changes as JSON array (e.g. [{"key":"voteExponent","value":"0.2","current":"0.1"}]):',
+      message: 'Enter parameter change sets as JSON array (e.g. [[{"key":"voteExponent","value":"1.2","current":"1.1"}]]):',
       default: '[]',
     },
     {
@@ -3190,9 +3202,7 @@ vorpal.command('dao proposal <number>', 'show details of a single DAO proposal')
       this.log(`Claim ends:   ${new Date(timing.claimEnd).toISOString()}`)
       // Content
       this.log(`Description:  ${p.description}`)
-      if (p.governance) this.log(`Changes:      ${JSON.stringify(p.governance.changes)}`)
-      if (p.economic) this.log(`Changes:      ${JSON.stringify(p.economic.changes)}`)
-      if (p.protocol) this.log(`Changes:      ${JSON.stringify(p.protocol.changes)}`)
+      this.log(`Changes:      ${formatDaoProposalChanges(p)}`)
     }
   } catch (err) {
     this.log('Error:', err.message)

--- a/scripts/test-dao-e2e.ts
+++ b/scripts/test-dao-e2e.ts
@@ -50,7 +50,7 @@ import * as net from 'net'
 import path from 'path'
 import * as ShardusCrypto from '@shardus/lib-crypto-utils'
 import { Utils } from '@shardus/lib-types'
-import { DaoProposalAccount } from '../src/@types'
+import type { DaoParamChange, DaoProposalAccount } from '../src/@types'
 import { computeClaimReward } from '../src/utils/daoClaimRewardMath'
 import { getReviewEnd, getVotingStart, getVotingEnd, getClaimEnd, getApplyEligibleAt } from '../src/accounts/daoProposalAccount'
 import { generateTxId } from '../src/utils'
@@ -1216,7 +1216,11 @@ async function getProposal(n: number): Promise<DaoProposalWithTiming> {
 }
 
 function archiverActiveVersionFromProposal(proposal: DaoProposalAccount): string | null {
-  const change = proposal.economic?.changes?.find(c => c.key === 'archiver')
+  const changes = proposal.economic?.changes
+  const flatChanges: DaoParamChange[] | undefined = Array.isArray(changes?.[0])
+    ? (changes as DaoParamChange[][]).flat()
+    : (changes as DaoParamChange[] | undefined)
+  const change = flatChanges?.find(c => c.key === 'archiver')
   if (!change) return null
   const value = safeParse(change.value)
   return value?.activeVersion == null ? null : String(value.activeVersion)
@@ -1347,6 +1351,8 @@ async function waitForListOfChangesFromReceipt(description: string, receipt: TxR
 }
 
 type ProposalType = 'governance' | 'economic' | 'protocol'
+type DaoProposalChange = { key: string; value: string; current: string }
+type DaoProposalChangeSets = DaoProposalChange[] | DaoProposalChange[][]
 
 interface ProposalCreateOptions {
   proposer: TestAccount
@@ -1355,7 +1361,7 @@ interface ProposalCreateOptions {
   title: string
   description: string
   options?: string[]
-  changes: Array<{ key: string; value: string; current: string }>
+  changes: DaoProposalChangeSets
   gracePeriodMs: number
   startTime?: number
   expectedBalanceDelta?: (receipt: TxReceipt) => bigint
@@ -1363,6 +1369,10 @@ interface ProposalCreateOptions {
 
 function proposalPayloadKey(type: ProposalType): 'governance' | 'economic' | 'protocol' {
   return type
+}
+
+function asChangeSets(changes: DaoProposalChangeSets): DaoProposalChange[][] {
+  return Array.isArray(changes[0]) ? changes as DaoProposalChange[][] : [changes as DaoProposalChange[]]
 }
 
 async function createDaoProposal(opts: ProposalCreateOptions): Promise<number> {
@@ -1381,7 +1391,7 @@ async function createDaoProposal(opts: ProposalCreateOptions): Promise<number> {
       description: opts.description,
       options: opts.options ?? ['no', 'yes'],
       gracePeriod: opts.gracePeriodMs,
-      [proposalPayloadKey(proposalType)]: { changes: opts.changes },
+      [proposalPayloadKey(proposalType)]: { changes: asChangeSets(opts.changes) },
       timestamp: Date.now(),
     }
     if (opts.startTime !== undefined) tx.startTime = opts.startTime
@@ -2139,6 +2149,7 @@ async function main(): Promise<void> {
   let sc17VoteThresholdUsdTarget = '150.0'
   let sc17UnapplyThreshold = 3
   let sc8NodeRewardTarget = '1.25'
+  let sc8NodeRewardAlternate = '9.99'
   let sc8ArchiverActiveVersionTarget = '3.7.10'
   let sc8TopLevelActiveVersionBefore = ''
   let sc8ArchiverMinVersionBefore = ''
@@ -2172,6 +2183,7 @@ async function main(): Promise<void> {
           proposer,
           title: 'Vote exponent adjustment',
           description: `Toggle voteExponent from ${currentVoteExponent} to ${sc1VoteExponentTarget}`,
+          options: ['no', 'Change vote exponent'],
           changes: [{ key: 'voteExponent', value: String(sc1VoteExponentTarget), current: String(currentVoteExponent) }],
           gracePeriodMs: graceDurationMs,
           expectedBalanceDelta: receipt => -(proposalFeeWei + asBigInt(receipt.transactionFee ?? 0n)),
@@ -2283,7 +2295,7 @@ async function main(): Promise<void> {
       '1.6  dao_vote x2 (voter1 + voter2, both vote option 1)',
       async () => {
         // weights[i] maps 1:1 by index onto proposal.options[i] — [0, 1] puts the vote's
-        // entire weight on options[1] ('yes') for negative-first DAO ballots.
+        // entire weight on options[1], the action option for negative-first DAO ballots.
         await castVote(proposalN.sc1, voter1, [0, 1], minVoteSpendLib, receipt => -(libToWei(minVoteSpendLib) + asBigInt(receipt.transactionFee ?? 0n)))
         await castVote(proposalN.sc1, voter2, [0, 1], minVoteSpendLib)
         const proposal = await getProposal(proposalN.sc1)
@@ -2531,11 +2543,11 @@ async function main(): Promise<void> {
   }
 
   // ─────────────────────────────────────────────────────────────────────────
-  // Scenario 3 — Auto-accept via dao_committee_result
+  // Scenario 3 — Zero-vote tie resolves to option 0
   // ─────────────────────────────────────────────────────────────────────────
   const sc3: ScenarioDef = {
     num: 3,
-    name: 'Scenario 3 — Auto-accept via committee_result (no committee votes submitted)',
+    name: 'Scenario 3 — Zero-vote tie resolves to option 0',
     setupSteps: [
     [
       '3.1  dao_proposal_create (non-emergency, no votes will be submitted)',
@@ -2543,7 +2555,7 @@ async function main(): Promise<void> {
         setProposalN('sc3', await createDaoProposal({
           proposer,
           title: 'Zero-vote acceptance',
-          description: 'Auto-accept test — committee_result will advance this after reviewEnd',
+          description: 'Zero-vote tie-break test — committee_result will advance this after reviewEnd',
           changes: [{ key: 'pctBurned', value: '55', current: '50' }],
           gracePeriodMs: graceDurationMs,
         }))
@@ -2643,12 +2655,42 @@ async function main(): Promise<void> {
             options: ['no', 'yes'],
             gracePeriod: graceDurationMs,
             governance: {
-              changes: [{ key: 'pctBurned', value: '70', current: '50' }],
+              changes: [[{ key: 'pctBurned', value: '70', current: '50' }]],
             },
             timestamp: Date.now(),
           }),
           voter1,
           'committee',
+        )
+      },
+    ],
+
+    [
+      '4.1b  Emergency proposal with multiple action change sets → rejected',
+      async () => {
+        await expectProposalCreateReject(
+          proposalNumber => ({
+            type: 'dao_proposal_create',
+            networkId: currentNetworkId,
+            from: committee[0].address,
+            proposalId: daoProposalId(proposalNumber),
+            metaId: ShardusCrypto.hash('dao proposals meta'),
+            proposalType: 'governance',
+            emergency: true,
+            title: 'Invalid emergency multi-action proposal',
+            description: 'Emergency proposal with multiple action options must be rejected',
+            options: ['no', 'Set burn to 70', 'Set burn to 65'],
+            gracePeriod: graceDurationMs,
+            governance: {
+              changes: [
+                [{ key: 'pctBurned', value: '70', current: '50' }],
+                [{ key: 'pctBurned', value: '65', current: '50' }],
+              ],
+            },
+            timestamp: Date.now(),
+          }),
+          committee[0],
+          'emergency',
         )
       },
     ],
@@ -2664,7 +2706,7 @@ async function main(): Promise<void> {
           emergency: true,
           title: 'Emergency burn adjustment',
           description: `Emergency governance proposal toggles pctBurned from ${currentPctBurned} to ${sc4PctBurnedTarget}`,
-          changes: [{ key: 'pctBurned', value: String(sc4PctBurnedTarget), current: String(currentPctBurned) }],
+          changes: [[{ key: 'pctBurned', value: String(sc4PctBurnedTarget), current: String(currentPctBurned) }]],
           gracePeriodMs: graceDurationMs,
         }))
         saveCurrentRunState()
@@ -2987,8 +3029,8 @@ async function main(): Promise<void> {
           proposer: proposer5,
           title: 'Weighted multi-option vote',
           description: 'Multi-option weighted vote test proposal',
-          options: ['no', 'yes', 'abstain'],
-          changes: [{ key: 'voteExponent', value: '0.3', current: '0.1' }],
+          options: ['no', 'Set exponent to 0.3', 'Set exponent to 0.4'],
+          changes: [[{ key: 'voteExponent', value: '0.3', current: '0.1' }], [{ key: 'voteExponent', value: '0.4', current: '0.1' }]],
           gracePeriodMs: graceDurationMs,
         }))
         saveCurrentRunState()
@@ -3055,12 +3097,17 @@ async function main(): Promise<void> {
       async () => {
         const currentValue = String(await getCurrentNetworkValue('nodeRewardAmountUsdStr'))
         sc8NodeRewardTarget = currentValue === '1.25' ? '1.35' : '1.25'
+        sc8NodeRewardAlternate = [currentValue, sc8NodeRewardTarget].includes('9.99') ? '9.98' : '9.99'
         setProposalN('sc8Economic', await createDaoProposal({
           proposer: proposer6,
           proposalType: 'economic',
           title: 'Node reward adjustment',
           description: `Economic proposal updates nodeRewardAmountUsdStr from ${currentValue} to ${sc8NodeRewardTarget}`,
-          changes: [{ key: 'nodeRewardAmountUsdStr', value: sc8NodeRewardTarget, current: currentValue }],
+          options: ['no', `Set node reward to ${sc8NodeRewardAlternate}`, `Set node reward to ${sc8NodeRewardTarget}`],
+          changes: [
+            [{ key: 'nodeRewardAmountUsdStr', value: sc8NodeRewardAlternate, current: currentValue }],
+            [{ key: 'nodeRewardAmountUsdStr', value: sc8NodeRewardTarget, current: currentValue }],
+          ],
           gracePeriodMs: graceDurationMs,
         }))
         saveCurrentRunState()
@@ -3082,7 +3129,7 @@ async function main(): Promise<void> {
             description: 'Invalid governance namespace test',
             options: ['no', 'yes'],
             gracePeriod: graceDurationMs,
-            governance: { changes: [{ key: 'nodeRewardAmountUsdStr', value: '1.5', current: '1.0' }] },
+            governance: { changes: [[{ key: 'nodeRewardAmountUsdStr', value: '1.5', current: '1.0' }]] },
             timestamp: Date.now(),
           }),
           proposer6,
@@ -3106,7 +3153,7 @@ async function main(): Promise<void> {
             description: 'Invalid protocol namespace test',
             options: ['no', 'yes'],
             gracePeriod: graceDurationMs,
-            protocol: { changes: [{ key: 'nodeRewardAmountUsdStr', value: '1.5', current: '1.25' }] },
+            protocol: { changes: [[{ key: 'nodeRewardAmountUsdStr', value: '1.5', current: '1.25' }]] },
             timestamp: Date.now(),
           }),
           proposer7,
@@ -3181,10 +3228,13 @@ async function main(): Promise<void> {
       '8.4  Economic proposal applies via apply_change_network_param',
       async () => {
         await committeeAcceptToVoting(proposalN.sc8Economic, proposer6, committee, SLEEP_BUFFER_MS, [1, 2, 3])
-        await castVote(proposalN.sc8Economic, voter7, [0, 1], minVoteSpendLib)
-        await finalizeVote(proposalN.sc8Economic, proposer6, SLEEP_BUFFER_MS)
+        await castVote(proposalN.sc8Economic, voter7, [0, 0, 1], minVoteSpendLib)
+        const { receipt: resultReceipt } = await finalizeVote(proposalN.sc8Economic, proposer6, SLEEP_BUFFER_MS)
+        assert(resultReceipt.additionalInfo?.winningOptionIndex === 2, `Expected winningOptionIndex 2, got ${JSON.stringify(resultReceipt.additionalInfo)}`)
         await applyAcceptedProposal(proposalN.sc8Economic, proposer6, SLEEP_BUFFER_MS, committee, cycleDurationMs, async receipt => {
           await waitForNetworkParameter(['current', 'nodeRewardAmountUsdStr'], sc8NodeRewardTarget, applyParamsPollMs)
+          const landedValue = String(await getCurrentNetworkValue('nodeRewardAmountUsdStr'))
+          assert(landedValue !== sc8NodeRewardAlternate, `Expected losing alternate ${sc8NodeRewardAlternate} not to land`)
           await waitForListOfChangesFromReceipt(
             `appData.nodeRewardAmountUsdStr=${sc8NodeRewardTarget}`,
             receipt,
@@ -3250,10 +3300,10 @@ async function main(): Promise<void> {
             options: ['no', 'yes'],
             gracePeriod: graceDurationMs,
             protocol: {
-              changes: [
+              changes: [[
                 { key: 'debug', value: '{"countEndpointStart":-3}', current: '{"countEndpointStart":-1}' },
                 { key: 'countEndpointStart', value: '-3', current: '-1' },
-              ],
+              ]],
             },
             timestamp: Date.now(),
           }),
@@ -3328,7 +3378,7 @@ async function main(): Promise<void> {
             description: 'Past startTime rejection test',
             options: ['no', 'yes'],
             gracePeriod: graceDurationMs,
-            governance: { changes: [{ key: 'pctBurned', value: '52', current: '50' }] },
+            governance: { changes: [[{ key: 'pctBurned', value: '52', current: '50' }]] },
             startTime: timestamp - 1,
             timestamp,
           }),
@@ -3638,7 +3688,7 @@ async function main(): Promise<void> {
             description: 'Too many options rejection',
             options: ['no', 'yes', '2', '3', '4', '5', '6', '7', '8', '9', '10'],
             gracePeriod: graceDurationMs,
-            governance: { changes: [{ key: 'pctBurned', value: '59', current: '50' }] },
+            governance: { changes: [[{ key: 'pctBurned', value: '59', current: '50' }]] },
             timestamp: Date.now(),
           }),
           proposer10,
@@ -3920,13 +3970,14 @@ async function main(): Promise<void> {
             reason: 'options[0]',
           },
           {
-            title: 'Invalid second option',
-            description: 'Invalid non-affirmative second option test',
+            title: 'Invalid flat changes payload',
+            description: 'Flat changes payload is legacy-only and rejected for new proposals',
             account: proposer3,
-            options: ['no', 'abstain'],
+            options: ['no', 'yes'],
             gracePeriod: graceDurationMs,
             changes: [{ key: 'pctBurned', value: '63', current: '50' }],
-            reason: 'options[1]',
+            useRawChanges: true,
+            reason: 'nested changes',
           },
           {
             title: '   ',
@@ -3989,7 +4040,7 @@ async function main(): Promise<void> {
               description: c.description,
               options: c.options,
               gracePeriod: c.gracePeriod,
-              governance: { changes: c.changes },
+              governance: { changes: c.useRawChanges ? c.changes : asChangeSets(c.changes) },
               timestamp: Date.now(),
             }),
             c.account,
@@ -4062,7 +4113,7 @@ async function main(): Promise<void> {
             options: ['no', 'yes'],
             gracePeriod: graceDurationMs,
             governance: {
-              changes: [{ key: 'committeeAddresses', value: JSON.stringify(invalidCommitteeAddresses), current: JSON.stringify(daoParams.committeeAddresses) }],
+              changes: [[{ key: 'committeeAddresses', value: JSON.stringify(invalidCommitteeAddresses), current: JSON.stringify(daoParams.committeeAddresses) }]],
             },
             timestamp: Date.now(),
           }),

--- a/src/@types/index.ts
+++ b/src/@types/index.ts
@@ -796,17 +796,23 @@ export interface DevAccount {
 // New DAO account types (Phase 1: governance/economic/protocol proposals)
 export type DaoProposalStatus = 'review' | 'withheld' | 'voting' | 'rejected' | 'accepted' | 'applied' | 'canceled'
 export type DaoProposalType = 'governance' | 'economic' | 'protocol'
+export interface DaoParamChange {
+  key: string
+  value: string
+  current: string
+}
+export type DaoParamChanges = DaoParamChange[] | DaoParamChange[][]
 
 export interface DaoGovernanceData {
-  changes: Array<{ key: string; value: string; current: string }>
+  changes: DaoParamChanges
 }
 
 export interface DaoEconomicData {
-  changes: Array<{ key: string; value: string; current: string }>
+  changes: DaoParamChanges
 }
 
 export interface DaoProtocolData {
-  changes: Array<{ key: string; value: string; current: string }>
+  changes: DaoParamChanges
 }
 
 export interface DaoProposalsMeta {
@@ -859,6 +865,7 @@ export interface DaoProposalAccount {
   // Voting state
   options: string[]
   totalVote: bigint[]
+  winningOptionIndex?: number
   // Fixed once dao_vote_result runs (post-burn pool); accumulates pre-burn (proposalFeeWei +
   // sum of vote spends). claimedReward tracks the running total paid out via dao_claim_reward;
   // remaining unclaimed = voterRewardPool - claimedReward.

--- a/src/transactions/dao/dao_apply_parameters.ts
+++ b/src/transactions/dao/dao_apply_parameters.ts
@@ -10,6 +10,7 @@ import { Utils } from '@shardus/lib-types'
 import { getApplyEligibleAt } from '../../accounts/daoProposalAccount'
 import { buildNestedChange, mergeNestedChange, resolveChanges, ResolvedChange } from '../../utils/daoParamResolver'
 import { coerce, validateChangesPayload } from '../../utils/daoParamValidation'
+import { getSelectedChanges } from '../../utils/daoProposalChangeSets'
 
 export const validate_fields = (tx: Tx.DaoApplyParameters, response: ShardusTypes.IncomingTransactionResult): ShardusTypes.IncomingTransactionResult => {
   if (utils.isValidAddress(tx.from) === false) {
@@ -75,7 +76,13 @@ export const validate = (
   }
 
   // Re-validate change keys and values against the live network state before applying.
-  const changes = getChanges(proposal)
+  let changes: ReturnType<typeof getSelectedChanges>
+  try {
+    changes = getSelectedChanges(proposal)
+  } catch (err) {
+    response.reason = err instanceof Error ? err.message : String(err)
+    return response
+  }
   const changesError = validateChangesPayload(proposal.proposalType, changes, network, dapp)
   if (changesError) {
     response.reason = changesError
@@ -105,10 +112,11 @@ export const apply = (
   const network = wrappedStates[config.networkAccount].data as NetworkAccount
   const txFeeWei = utils.getTransactionFeeWei(AccountsStorage.cachedNetworkAccount)
 
+  const changes = getSelectedChanges(proposal)
+  const resolvedChanges = resolveChanges(proposal.proposalType, network, dapp, changes)
+
   from.data.balance = SafeBigIntMath.subtract(from.data.balance, txFeeWei)
 
-  const changes = getChanges(proposal)
-  const resolvedChanges = resolveChanges(proposal.proposalType, network, dapp, changes)
   const when = txTimestamp + config.ONE_SECOND * 10
   const now = dapp.shardusGetTime()
   console.log(
@@ -166,19 +174,6 @@ export const apply = (
   const appReceiptDataHash = crypto.hashObj(appReceiptData)
   dapp.applyResponseAddReceiptData(applyResponse, appReceiptData, appReceiptDataHash)
   dapp.log('Applied dao_apply_parameters tx', tx.proposalId, proposal.proposalType, changes.length, 'changes', Utils.safeStringify(value))
-}
-
-function getChanges(proposal: DaoProposalAccount): Array<{ key: string; value: string }> {
-  if (proposal.proposalType === 'governance' && proposal.governance) {
-    return proposal.governance.changes
-  }
-  if (proposal.proposalType === 'economic' && proposal.economic) {
-    return proposal.economic.changes
-  }
-  if (proposal.proposalType === 'protocol' && proposal.protocol) {
-    return proposal.protocol.changes
-  }
-  return []
 }
 
 function buildConfigChange(resolvedChanges: ResolvedChange[]): Record<string, unknown> {

--- a/src/transactions/dao/dao_proposal_create.ts
+++ b/src/transactions/dao/dao_proposal_create.ts
@@ -8,8 +8,8 @@ import { SafeBigIntMath } from '../../utils/safeBigIntMath'
 import * as AccountsStorage from '../../storage/accountStorage'
 import { isUserAccount, isDaoProposalsMeta, isDaoProposalAccount } from '../../@types/accountTypeGuards'
 import { DAO_PROPOSALS_META_ID_STRING } from '../../accounts/daoProposalsMetaAccount'
-import { validateChangesPayload } from '../../utils/daoParamValidation'
 import { validateDaoOptions } from '../../utils/daoBallotOptions'
+import { validateProposalChangeSets } from '../../utils/daoProposalChangeSets'
 
 export const validate_fields = (
   tx: Tx.DaoProposalCreate,
@@ -63,38 +63,7 @@ export const validate_fields = (
     return response
   }
   const payload = tx[tx.proposalType as 'governance' | 'economic' | 'protocol']
-  if (!payload || !Array.isArray(payload.changes) || payload.changes.length === 0) {
-    response.reason = `tx "${tx.proposalType}" payload must include a non-empty "changes" array`
-    return response
-  }
-  // Structural check: validate field types and reject duplicate raw keys before the
-  // heavier path-resolution and coerce pass in validateChangesPayload below.
-  const seenKeys = new Set<string>()
-  for (const [i, change] of payload.changes.entries()) {
-    if (change === null || typeof change !== 'object') {
-      response.reason = `each change must be an object { key: string; value: string; current: string } - got ${change === null ? 'null' : typeof change} at changes[${i}]`
-      return response
-    }
-    if (typeof change.key !== 'string' || change.key.length === 0) {
-      response.reason = `each change must have a non-empty string "key" - got ${change.key === '' ? 'an empty string' : typeof change.key} at changes[${i}].key`
-      return response
-    }
-    if (typeof change.value !== 'string') {
-      response.reason = `each change must have a string "value" - got ${typeof change.value} at the "value" for key '${change.key}'`
-      return response
-    }
-    if (typeof change.current !== 'string') {
-      response.reason = `each change must have a string "current" - got ${typeof change.current} at the "current" for key '${change.key}'`
-      return response
-    }
-    if (seenKeys.has(change.key)) {
-      response.reason = `each change must have a unique "key" - got duplicate "${change.key}"`
-      return response
-    }
-    seenKeys.add(change.key)
-  }
-  // Quick check using cached network account.
-  const changesError = validateChangesPayload(tx.proposalType, payload.changes, AccountsStorage.cachedNetworkAccount, dapp)
+  const changesError = validateProposalChangeSets(tx.proposalType, tx.options, payload?.changes ?? [], AccountsStorage.cachedNetworkAccount, dapp, tx.emergency)
   if (changesError) {
     response.reason = changesError
     return response
@@ -168,7 +137,7 @@ export const validate = (
 
   // Recheck with live wrappedStates — validate_fields ran against the cached network account.
   const txPayload = tx[tx.proposalType as 'governance' | 'economic' | 'protocol']
-  const changesError = validateChangesPayload(tx.proposalType, txPayload?.changes ?? [], network, dapp)
+  const changesError = validateProposalChangeSets(tx.proposalType, tx.options, txPayload?.changes ?? [], network, dapp, tx.emergency)
   if (changesError) {
     response.reason = changesError
     return response

--- a/src/transactions/dao/dao_vote_result.ts
+++ b/src/transactions/dao/dao_vote_result.ts
@@ -88,6 +88,7 @@ export const apply = (
   }
 
   const winningOption = proposal.options[winnerIndex]
+  proposal.winningOptionIndex = winnerIndex
   proposal.status = isWinningOptionAccepted(proposal.options, winnerIndex) ? 'accepted' : 'rejected'
   // Record the real time this ran, so claimEnd/applyEligibleAt reflect it.
   proposal.votingEndedAt = txTimestamp
@@ -114,6 +115,7 @@ export const apply = (
     transactionFee: txFeeWei,
     additionalInfo: {
       winningOption,
+      winningOptionIndex: winnerIndex,
       proposalStatus: proposal.status,
       burnAmount,
       voterRewardPool: proposal.voterRewardPool,

--- a/src/utils/daoBallotOptions.ts
+++ b/src/utils/daoBallotOptions.ts
@@ -25,9 +25,6 @@ export function validateDaoOptions(options: string[]): string | undefined {
   if (!isNegativeOption(options[0])) {
     return `tx "options[0]" must be a recognized rejection choice (one of: ${NEGATIVE_OPTION_STRINGS.join(', ')})`
   }
-  if (!isAffirmativeOption(options[1])) {
-    return `tx "options[1]" must be a recognized acceptance choice (one of: ${AFFIRMATIVE_OPTION_STRINGS.join(', ')})`
-  }
   return undefined
 }
 
@@ -35,8 +32,8 @@ export function isWinningOptionAccepted(options: string[], winnerIndex: number):
   if (!Array.isArray(options) || winnerIndex < 0 || winnerIndex >= options.length) {
     return false
   }
-  if (options.length >= 2 && isNegativeOption(options[0]) && isAffirmativeOption(options[1])) {
-    return winnerIndex === 1
+  if (isNegativeOption(options[0])) {
+    return winnerIndex > 0
   }
   if (isAffirmativeOption(options[0])) {
     return winnerIndex === 0

--- a/src/utils/daoProposalChangeSets.ts
+++ b/src/utils/daoProposalChangeSets.ts
@@ -1,0 +1,95 @@
+import type { Shardus } from '@shardus/core'
+import type { DaoParamChange, DaoParamChanges, DaoProposalAccount, DaoProposalType, NetworkAccount } from '../@types'
+import { validateChangesPayload } from './daoParamValidation'
+
+export function isNestedChangeSets(changes: DaoParamChanges): changes is DaoParamChange[][] {
+  return Array.isArray(changes[0])
+}
+
+export function validateProposalChangeSets(
+  proposalType: DaoProposalType,
+  options: string[],
+  changes: DaoParamChanges,
+  network: NetworkAccount | undefined,
+  dapp: Shardus | undefined,
+  emergency: boolean,
+): string | undefined {
+  if (!Array.isArray(changes) || changes.length === 0) {
+    return `tx "${proposalType}" payload must include a non-empty "changes" array`
+  }
+
+  if (isNestedChangeSets(changes)) {
+    if (changes.length !== options.length - 1) {
+      return `nested changes must have exactly one change set for each non-rejection option (expected ${options.length - 1}, got ${changes.length})`
+    }
+    if (emergency && (options.length !== 2 || changes.length !== 1)) {
+      return 'emergency DAO proposals must have exactly one action option and one change set'
+    }
+    for (const [i, changeSet] of changes.entries()) {
+      const structuralError = validateChangeSet(changeSet, `changes[${i}]`)
+      if (structuralError) return structuralError
+      const changesError = validateChangesPayload(proposalType, changeSet, network, dapp)
+      if (changesError) return changesError
+    }
+    return undefined
+  }
+
+  // Create-time only: apply still accepts flat changes for proposals created before change sets existed.
+  return 'new DAO proposals must use nested changes: wrap each option change set in its own array, e.g. [[{...}]]'
+}
+
+export function getSelectedChanges(proposal: DaoProposalAccount): DaoParamChange[] {
+  const changes = getProposalChanges(proposal)
+  if (!changes || changes.length === 0) return []
+  // Legacy proposals created before multi-option change sets stored a flat changes array.
+  if (!isNestedChangeSets(changes)) return changes
+  if (proposal.emergency) {
+    if (!changes[0] || changes[0].length === 0) throw new Error('Emergency proposal has no action change set')
+    return changes[0]
+  }
+
+  const winnerIndex = proposal.winningOptionIndex
+  const selectedChanges = winnerIndex === undefined || !Number.isInteger(winnerIndex) || winnerIndex <= 0 ? undefined : changes[winnerIndex - 1]
+  if (!selectedChanges || selectedChanges.length === 0) {
+    throw new Error('Proposal has no valid winning option change set')
+  }
+  return selectedChanges
+}
+
+function getProposalChanges(proposal: DaoProposalAccount): DaoParamChanges | undefined {
+  if (proposal.proposalType === 'governance') return proposal.governance?.changes
+  if (proposal.proposalType === 'economic') return proposal.economic?.changes
+  if (proposal.proposalType === 'protocol') return proposal.protocol?.changes
+  return undefined
+}
+
+function validateChangeSet(changes: unknown, path: string): string | undefined {
+  if (!Array.isArray(changes) || changes.length === 0) {
+    return `${path} must be a non-empty array of change objects`
+  }
+
+  const seenKeys = new Set<string>()
+  for (const [i, change] of changes.entries()) {
+    const itemPath = `${path}[${i}]`
+    if (change === null || typeof change !== 'object' || Array.isArray(change)) {
+      const actualType = change === null ? 'null' : Array.isArray(change) ? 'array' : typeof change
+      return `each change must be an object { key: string; value: string; current: string } - got ${actualType} at ${itemPath}`
+    }
+    const paramChange = change as Partial<DaoParamChange>
+    if (typeof paramChange.key !== 'string' || paramChange.key.length === 0) {
+      return `each change must have a non-empty string "key" - got ${paramChange.key === '' ? 'an empty string' : typeof paramChange.key} at ${itemPath}.key`
+    }
+    if (typeof paramChange.value !== 'string') {
+      return `each change must have a string "value" - got ${typeof paramChange.value} at the "value" for key '${paramChange.key}'`
+    }
+    if (typeof paramChange.current !== 'string') {
+      return `each change must have a string "current" - got ${typeof paramChange.current} at the "current" for key '${paramChange.key}'`
+    }
+    if (seenKeys.has(paramChange.key)) {
+      return `each change set must have unique "key" entries - got duplicate "${paramChange.key}"`
+    }
+    seenKeys.add(paramChange.key)
+  }
+
+  return undefined
+}

--- a/test/daoBallotOptions.test.ts
+++ b/test/daoBallotOptions.test.ts
@@ -1,7 +1,7 @@
 import { isWinningOptionAccepted, validateDaoOptions } from '../src/utils/daoBallotOptions'
 
 describe('dao ballot options', () => {
-  test('negative-first binary ballots accept only option 1', () => {
+  test('negative-first binary ballots reject option 0 and accept option 1', () => {
     expect(validateDaoOptions(['no', 'yes'])).toBeUndefined()
     expect(isWinningOptionAccepted(['no', 'yes'], 0)).toBe(false)
     expect(isWinningOptionAccepted(['no', 'yes'], 1)).toBe(true)
@@ -17,11 +17,17 @@ describe('dao ballot options', () => {
     expect(isWinningOptionAccepted(['deny', 'approve'], 1)).toBe(true)
   })
 
-  test('negative-first multi-option ballots accept only option 1', () => {
+  test('negative-first multi-option ballots accept any non-zero winner', () => {
     expect(validateDaoOptions(['no', 'yes', 'abstain'])).toBeUndefined()
     expect(isWinningOptionAccepted(['no', 'yes', 'abstain'], 0)).toBe(false)
     expect(isWinningOptionAccepted(['no', 'yes', 'abstain'], 1)).toBe(true)
-    expect(isWinningOptionAccepted(['no', 'yes', 'abstain'], 2)).toBe(false)
+    expect(isWinningOptionAccepted(['no', 'yes', 'abstain'], 2)).toBe(true)
+  })
+
+  test('negative-first action labels do not need to be affirmative keywords', () => {
+    expect(validateDaoOptions(['no', 'Increase burn'])).toBeUndefined()
+    expect(validateDaoOptions(['no', 'abstain'])).toBeUndefined()
+    expect(isWinningOptionAccepted(['no', 'Increase burn'], 1)).toBe(true)
   })
 
   test('old affirmative-first ballots still resolve for in-flight proposals', () => {
@@ -32,7 +38,6 @@ describe('dao ballot options', () => {
 
   test('invalid new proposal option layouts are rejected', () => {
     expect(validateDaoOptions(['maybe', 'yes'])).toContain('options[0]')
-    expect(validateDaoOptions(['no', 'abstain'])).toContain('options[1]')
     expect(validateDaoOptions(['no'])).toContain('2 to 10')
     expect(validateDaoOptions(['no', 'yes', '2', '3', '4', '5', '6', '7', '8', '9', '10'])).toContain('2 to 10')
   })

--- a/test/daoProposalChangeSets.test.ts
+++ b/test/daoProposalChangeSets.test.ts
@@ -1,0 +1,85 @@
+jest.mock('../src/utils/daoParamValidation', () => ({
+  validateChangesPayload: jest.fn(() => undefined),
+}))
+
+import type { DaoProposalAccount } from '../src/@types'
+import { validateChangesPayload } from '../src/utils/daoParamValidation'
+import { getSelectedChanges, isNestedChangeSets, validateProposalChangeSets } from '../src/utils/daoProposalChangeSets'
+
+const changeA = { key: 'pctBurned', value: '60', current: '50' }
+const changeB = { key: 'pctBurned', value: '70', current: '50' }
+
+function proposalWithChanges(changes: unknown, winningOptionIndex?: number, emergency = false): DaoProposalAccount {
+  return {
+    proposalType: 'governance',
+    emergency,
+    options: ['no', 'Set burn to 60', 'Set burn to 70'],
+    winningOptionIndex,
+    governance: { changes },
+  } as DaoProposalAccount
+}
+
+describe('dao proposal change sets', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  test('detects nested change sets', () => {
+    expect(isNestedChangeSets([changeA])).toBe(false)
+    expect(isNestedChangeSets([[changeA], [changeB]])).toBe(true)
+  })
+
+  test('selected nested change set maps option index minus one', () => {
+    const proposal = proposalWithChanges([[changeA], [changeB]], 2)
+    expect(getSelectedChanges(proposal)).toEqual([changeB])
+  })
+
+  test('flat changes are selected directly', () => {
+    const proposal = proposalWithChanges([changeA])
+    expect(getSelectedChanges(proposal)).toEqual([changeA])
+  })
+
+  test('nested regular proposal fails closed without a valid winning option', () => {
+    expect(() => getSelectedChanges(proposalWithChanges([[changeA], [changeB]], 0))).toThrow('winning option')
+    expect(() => getSelectedChanges(proposalWithChanges([[changeA], [changeB]], 3))).toThrow('winning option')
+    expect(() => getSelectedChanges(proposalWithChanges([[changeA], []], 2))).toThrow('winning option')
+  })
+
+  test('emergency nested proposal selects its single action change set without a winning option', () => {
+    const proposal = proposalWithChanges([[changeA]], undefined, true)
+    expect(getSelectedChanges(proposal)).toEqual([changeA])
+  })
+
+  test('flat changes are rejected for new proposal creation', () => {
+    expect(validateProposalChangeSets('governance', ['no', 'A'], [changeA], undefined, undefined, false)).toContain('nested changes')
+    expect(validateProposalChangeSets('governance', ['no', 'A', 'B'], [changeA], undefined, undefined, false)).toContain('nested changes')
+  })
+
+  test('invalid change payload shapes are rejected', () => {
+    expect(validateProposalChangeSets('governance', ['no', 'A'], [], undefined, undefined, false)).toContain('non-empty')
+    expect(validateProposalChangeSets('governance', ['no', 'A'], 'bad' as any, undefined, undefined, false)).toContain('non-empty')
+    expect(validateProposalChangeSets('governance', ['no', 'A', 'B'], [[changeA], changeB] as any, undefined, undefined, false)).toContain('array')
+    expect(validateProposalChangeSets('governance', ['no', 'A'], [[]], undefined, undefined, false)).toContain('non-empty')
+  })
+
+  test('nested changes require one set per non-rejection option', () => {
+    expect(validateProposalChangeSets('governance', ['no', 'A', 'B'], [[changeA]], undefined, undefined, false)).toContain('one change set')
+  })
+
+  test('emergency nested proposals allow only one action change set', () => {
+    expect(validateProposalChangeSets('governance', ['no', 'A'], [[changeA]], undefined, undefined, true)).toBeUndefined()
+    expect(validateProposalChangeSets('governance', ['no', 'A', 'B'], [[changeA], [changeB]], undefined, undefined, true)).toContain('emergency')
+  })
+
+  test('duplicate keys are scoped to each change set', () => {
+    expect(validateProposalChangeSets('governance', ['no', 'A'], [[changeA, changeA]], undefined, undefined, false)).toContain('duplicate')
+    expect(validateProposalChangeSets('governance', ['no', 'A', 'B'], [[changeA], [changeB]], undefined, undefined, false)).toBeUndefined()
+  })
+
+  test('each valid nested change set is passed to parameter validation', () => {
+    expect(validateProposalChangeSets('governance', ['no', 'A', 'B'], [[changeA], [changeB]], undefined, undefined, false)).toBeUndefined()
+    expect(validateChangesPayload).toHaveBeenCalledTimes(2)
+    expect(validateChangesPayload).toHaveBeenNthCalledWith(1, 'governance', [changeA], undefined, undefined)
+    expect(validateChangesPayload).toHaveBeenNthCalledWith(2, 'governance', [changeB], undefined, undefined)
+  })
+})


### PR DESCRIPTION
- allow negative-first DAO ballots where any non-zero option can accept

- require nested change sets for all new DAO proposals and select the winning option change set at apply time

- preserve flat-change compatibility only for existing proposal accounts created before change sets existed

- update client display, focused unit tests, and DAO E2E coverage for nested regular and emergency proposals